### PR TITLE
Udpated to odoo v8.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -7,16 +7,16 @@ export LANG=en_US.UTF-8
 export LC_ALL=en_US.UTF-8
 sudo dpkg-reconfigure locales
 
-# Add openerp repository
-echo "deb http://nightly.openerp.com/7.0/nightly/deb/ ./" | sudo tee -a /etc/apt/sources.list
+# Add odoo (originaly openerp) repository
+echo "deb http://nightly.openerp.com/8.0/nightly/deb/ ./" | sudo tee -a /etc/apt/sources.list
 
 # update the sources list
 sudo apt-get update
 
-# Install openerp
-sudo apt-get -y --force-yes install openerp
+# Install odoo
+sudo apt-get -y --force-yes install odoo
 
 # Add the postgres user
-sudo -u postgres createuser --createdb --no-createrole --no-superuser -w openerp
+sudo -u postgres createuser --createdb --no-createrole --no-superuser -w odoo
 
 echo ">>> Complete Install Script"


### PR DESCRIPTION
Hey !

Trying to follow on http://openerpacademy.com/screencasts/install-openerp-ubuntu-vagrant/, I've find a simple way to update to 8.0.
The vagrant machine seems to work well on OSX 10.9, haven't tested it more than a few minutes though.

Best,
Matthieu
